### PR TITLE
Add ability to see icons when using rating forms

### DIFF
--- a/src/contentStyle.css
+++ b/src/contentStyle.css
@@ -17,7 +17,7 @@
 .workable-blind-toggled .avatar-large,
 .workable-blind-toggled .avatar-jumbo,
 .workable-blind-toggled .search-result__container img {
-    -webkit-filter: blur(3px) grayscale(100%);    
+    -webkit-filter: blur(3px) grayscale(100%);
 }
 .workable-blind-toggled .rating-summary,
 .workable-blind-toggled .rating-widget,
@@ -25,7 +25,8 @@
     visibility:hidden;
 }
 .workable-blind-toggled .icon-thumb-down,
-.workable-blind-toggled .icon-thumb-up {
+.workable-blind-toggled .icon-thumb-up,
+.workable-blind-toggled .icon-definitely {
     display:none;
 }
 

--- a/src/contentStyle.css
+++ b/src/contentStyle.css
@@ -24,9 +24,9 @@
 .workable-blind-toggled .timeline__icon {
     visibility:hidden;
 }
-.workable-blind-toggled .icon-thumb-down,
-.workable-blind-toggled .icon-thumb-up,
-.workable-blind-toggled .icon-definitely {
+.workable-blind-toggled :not(.rating-form) .icon-thumb-down,
+.workable-blind-toggled :not(.rating-form) .icon-thumb-up,
+.workable-blind-toggled :not(.rating-form) .icon-definitely {
     display:none;
 }
 


### PR DESCRIPTION
Adding the ability to see ratings when a user is filling out a ratings form in various parts of the application process. While it's important that we hide these icons, unhiding them in the form that only that user is viewing is okay.


Fixes #2 